### PR TITLE
Create symlinks when processing multiple files.

### DIFF
--- a/converter.go
+++ b/converter.go
@@ -107,19 +107,25 @@ func main() {
 		for _, winFile := range winFiles {
 			for _, pair := range mapped.Pairs {
 				if pair.Windows == winFile.Name() {
-					for _, linuxName := range pair.Linux {
-						fmt.Println("  " + winFile.Name() + " -> " + linuxName)
-						input, err := ioutil.ReadFile(orgDir + "/" + winFile.Name())
-						if err != nil {
-							fmt.Println(err)
-							return
-						}
+					for index, linuxName := range pair.Linux {
+						if index == 0 {
+							fmt.Println("  " + winFile.Name() + " -> " + linuxName)
+							input, err := ioutil.ReadFile(orgDir + "/" + winFile.Name())
+							if err != nil {
+								fmt.Println(err)
+								return
+							}
 
-						err = ioutil.WriteFile(linuxCursorDir+"/"+linuxName, input, 0644)
-						if err != nil {
-							fmt.Println("Error creating", linuxCursorDir+"/"+linuxName)
-							fmt.Println(err)
-							return
+							err = ioutil.WriteFile(linuxCursorDir+"/"+linuxName, input, 0644)
+							if err != nil {
+								fmt.Println("Error creating", linuxCursorDir+"/"+linuxName)
+								fmt.Println(err)
+								return
+							}
+						} else {
+							firstLinuxName := pair.Linux[0]
+							fmt.Println("  " + winFile.Name() + " -> " + linuxName + " (symlink to: " + firstLinuxName + ")")
+							os.Symlink(firstLinuxName, linuxCursorDir+"/"+linuxName)
 						}
 					}
 				}


### PR DESCRIPTION
Creating symbolic links for the secondary files in the map, no need to create duplicate images.
Sample result:
```
win2xcur Unzipped/NoshiroCursorver100/*.ani -o Converted/NoshiroCursorver100
Sorting NoshiroCursorver100
  01-Normal -> arrow
  01-Normal -> default (symlink to: arrow)
  01-Normal -> left_ptr (symlink to: arrow)
  01-Normal -> top_left_arrow (symlink to: arrow)
  02-Link -> hand
  02-Link -> hand1 (symlink to: hand)
  02-Link -> hand2 (symlink to: hand)
  02-Link -> openhand (symlink to: hand)
  02-Link -> pointer (symlink to: hand)
  02-Link -> pointing_hand (symlink to: hand)
  03-Loading -> half-busy
  03-Loading -> left_ptr_watch (symlink to: half-busy)
  03-Loading -> progress (symlink to: half-busy)
  03-Loading -> wait (symlink to: half-busy)
  03-Loading -> watch (symlink to: half-busy)
  04-Help -> help
  04-Help -> left_ptr_help (symlink to: help)
  04-Help -> question_arrow (symlink to: help)
  04-Help -> whats_this (symlink to: help)
```
```
tree ./Sorted
./Sorted
└── NoshiroCursorver100
    ├── cursors
    │   ├── all-scroll
    │   ├── arrow
    │   ├── bottom_left_corner
    │   ├── bottom_right_corner
    │   ├── bottom_side
    │   ├── cell
    │   ├── circle
    │   ├── closedhand -> all-scroll
    │   ├── col-resize
    │   ├── cross -> cell
    │   ├── crossed_circle -> circle
    │   ├── crosshair -> cell
    │   ├── default -> arrow
    │   ├── dnd-move -> all-scroll
    │   ├── dnd-no-drop -> circle
    │   ├── dnd-none -> all-scroll
    │   ├── down-arrow -> col-resize
    │   ├── draft
    │   ├── e-resize -> col-resize
    │   ├── ew-resize -> col-resize
    │   ├── fleur -> all-scroll
    │   ├── forbidden -> circle
    │   ├── grab -> all-scroll
    │   ├── grabbing -> all-scroll
    │   ├── half-busy
    │   ├── hand
    │   ├── hand1 -> hand
    │   ├── hand2 -> hand
...
```